### PR TITLE
店舗一覧ページにソート機能を実装

### DIFF
--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -41,6 +41,7 @@ class ShopController extends Controller
         $genres = array_unique($genres);
 
         // 検索処理
+        $input_sort = $request->sort;
         $input_area = $request->area;
         $input_genre = $request->genre;
         $input_name = $request->name;
@@ -79,6 +80,19 @@ class ShopController extends Controller
             }
         }
 
+        // ソート処理
+        if ( !empty($input_sort) ) {
+            if ($input_sort === 'ランダム') { $shops = $shops->shuffle(); }
+            if ($input_sort === '評価が高い順') { $shops = $shops->sortByDesc('rating'); }
+            if ($input_sort === '評価が低い順') {
+                $shops = $shops->sortBy('rating');
+                list($review_not_empty, $review_empty) = $shops->partition(function($shop){
+                    return ($shop->rating > 0);
+                });
+                $shops = $review_not_empty->merge($review_empty);
+            }
+        }
+
         // ページネーション
         $shops = new LengthAwarePaginator(
             $shops->forPage($request->page, 20),
@@ -94,6 +108,7 @@ class ShopController extends Controller
                 'shops',
                 'areas',
                 'genres',
+                'input_sort',
                 'input_area',
                 'input_genre',
                 'input_name',

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -76,17 +76,20 @@ class Shop extends Model
         $count_num = 0;
 
         $reviews = $this->reviews;
-        if ($reviews) {
+        if ($reviews->isNotEmpty()) {
             foreach ($reviews as $review) {
                 $total_review_rating += ($review->rating ?? 0);
                 $count_num++;
             }
-        }
 
-        $shop_rating = (($standard_value * $weight) + $total_review_rating) / ($weight + $count_num);
-        // 小数点第3位を四捨五入＆小数点以下2桁で揃える
-        $shop_rating = round($shop_rating, 2);
-        $shop_rating = number_format($shop_rating, 2);
+            $shop_rating = (($standard_value * $weight) + $total_review_rating) / ($weight + $count_num);
+            // 小数点第3位を四捨五入＆小数点以下2桁で揃える
+            $shop_rating = round($shop_rating, 2);
+            $shop_rating = number_format($shop_rating, 2);
+        } else {
+            $shop_rating = 0;
+            $shop_rating = number_format($shop_rating, 2);
+        }
 
         return $shop_rating;
     }

--- a/public/css/shop_all.css
+++ b/public/css/shop_all.css
@@ -4,7 +4,6 @@
 }
 
 .search-form {
-    width: 50%;
     padding: 10px;
     background-color: white;
     border: solid 1px #ddd;
@@ -12,24 +11,24 @@
     box-shadow: 2px 2px 3px #aaa;
     display: flex;
     align-items: center;
+    font-size: 14px;
 }
 
+.form__sort,
 .form__area,
 .form__genre {
-    width: 20%;
+    display: flex;
     padding: 0 8px;
-    text-align: center;
     border-right: solid 1px #ddd;
 }
 
+.form__sort select,
 .form__area select,
 .form__genre select {
     border: none;
-    width: 100%;
 }
 
 .form__name {
-    width: 60%;
     padding-left: 8px;
     display: flex;
     align-items: center;
@@ -41,8 +40,14 @@
 }
 
 .form__name input {
-    width: 90%;
     border: none;
+}
+
+.shop-list-top {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .shop-list-section {
@@ -150,7 +155,6 @@
 
 /* ページネーションカスタマイズ */
 .pagination {
-    margin-top: 20px;
     text-align: right;
 }
 
@@ -190,8 +194,18 @@
 
 /* レスポンシブ（タブレット） */
 @media screen and (max-width: 960px) {
+    .search-section {
+        margin-top: 60px;
+    }
+
     .search-form {
-        width: 70%;
+        width: 100%;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    .shop-list-top {
+        display: block;
     }
 
     .shop-card {
@@ -212,17 +226,16 @@
     }
 
     .search-form {
-        width: 100%;
-        flex-wrap: wrap;
-        gap: 10px;
+        display: block;
     }
 
+    .form__sort,
     .form__area,
     .form__genre {
-        width: 40%;
-        padding: 0 10px 0 0;
+        padding: 0 0 4px 0;
+        margin-bottom: 4px;
         border: none;
-        border-right: solid 1px #ddd;
+        border-bottom: solid 1px #ddd;
     }
     .form__name {
         width: 100%;
@@ -236,7 +249,8 @@
         width: 100%;
     }
 
-    .pagination {
-        text-align: center;
+    .pagination a,
+    .pagination span {
+        padding: 4px 10px;
     }
 }

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -283,7 +283,13 @@
                                 <img src="{{ asset('img/star_on_gray.svg') }}" class="image--star" alt="star">
                                 @endif
                                 @endfor
-                                <span class="rating-value">{{ $shop->rating }}</span>
+                                <span class="rating-value">
+                                    @if($shop->rating == 0)
+                                    投稿なし
+                                    @else
+                                    {{ $shop->rating }}
+                                    @endif
+                                </span>
                     </div>
                     <div class="card-content__info">
                         <img src="{{ asset('img/speech_bubble_beige.svg') }}" alt="speech_bubble">

--- a/resources/views/shop_all.blade.php
+++ b/resources/views/shop_all.blade.php
@@ -11,6 +11,15 @@
 @section('content')
 <div class="search-section">
     <form action="" class="search-form">
+        <div class="form__sort">
+            <span>並び替え：</span>
+            <select name="sort" onchange="submit(this.form)">
+                <option value=""></option>
+                <option value="ランダム" {{ $input_sort == 'ランダム' ? 'selected' : '' }}>ランダム</option>
+                <option value="評価が高い順" {{ $input_sort == '評価が高い順' ? 'selected' : '' }}>評価が高い順</option>
+                <option value="評価が低い順" {{ $input_sort == '評価が低い順' ? 'selected' : '' }}>評価が低い順</option>
+            </select>
+        </div>
         <div class="form__area">
             <select name="area" onchange="submit(this.form)">
                 <option value="">All area</option>
@@ -37,7 +46,18 @@
         </div>
     </form>
 </div>
-<div class="pagination">{{ $shops->appends(request()->query())->links('vendor.pagination.default') }}</div>
+<div class="shop-list-top">
+    <div class="search-info">
+        @if($input_sort || $input_area || $input_genre || $input_name)
+        <span>検索情報：</span>
+        @endif
+        @if($input_sort) <span>"{{ $input_sort }}"&nbsp;</span> @endif
+        @if($input_area) <span>"{{ $input_area }}"&nbsp;</span> @endif
+        @if($input_genre) <span>"{{ $input_genre }}"&nbsp;</span> @endif
+        @if($input_name) <span>"{{ $input_name }}"</span> @endif
+        </div>
+    <div class="pagination">{{ $shops->appends(request()->query())->onEachSide(1)->links('vendor.pagination.default') }}</div>
+</div>
 <div class="shop-list-section">
     @foreach($shops as $shop)
     <div class="shop-card">
@@ -62,7 +82,13 @@
                     <img src="{{ asset('img/star_on_gray.svg') }}" class="image--star" alt="star">
                     @endif
                 @endfor
-                <span class="rating-value">{{ $shop->rating }}</span>
+                <span class="rating-value">
+                    @if($shop->rating == 0)
+                    投稿なし
+                    @else
+                    {{ $shop->rating }}
+                    @endif
+                </span>
             </div>
             <div class="card-content__info">
                 <img src="{{ asset('img/speech_bubble_beige.svg') }}" alt="speech_bubble">

--- a/resources/views/store_shop_review.blade.php
+++ b/resources/views/store_shop_review.blade.php
@@ -38,7 +38,13 @@
                                 <img src="{{ asset('img/star_on_gray.svg') }}" class="image--star" alt="star">
                                 @endif
                             @endfor
-                            <span class="rating-value">{{ $shop->rating }}</span>
+                            <span class="rating-value">
+                                @if($shop->rating == 0)
+                                投稿なし
+                                @else
+                                {{ $shop->rating }}
+                                @endif
+                            </span>
                         </div>
                         <div class="card-content__info">
                             <img src="{{ asset('img/speech_bubble_beige.svg') }}" alt="speech_bubble">


### PR DESCRIPTION
## 【概要】
店舗一覧ページにソート機能を実装

## 【実装内容詳細】
- 店舗一覧ページのビューファイルを以下の通り修正
	- 検索箇所に「並び替え」欄を追加
	- ソート／検索を行った際の「検索情報」表示を追加
- ShopContoller.phpの店舗一覧ページ表示処理内にソート処理を追加
- Shopモデルクラスにおける「店舗のレーティング値取得メソッド」を調整（口コミが無い場合は "0.00" を返すように修正）
- 店舗カード表示時、レーティング値が "0.00" の場合は "投稿なし" と表示するように修正