### PR TITLE
csvインポート機能実装

### DIFF
--- a/app/Http/Requests/ShopDataFromCSVRequest.php
+++ b/app/Http/Requests/ShopDataFromCSVRequest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\File;
+use Illuminate\Validation\Validator;
+
+class ShopDataFromCSVRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'csv' => [
+                'required',
+                'file',
+                'extensions:csv',
+            ],
+            'shop_data.*.owner_id' => ['required'],
+            'shop_data.*.name' => ['required', 'max:50'],
+            'shop_data.*.area' => ['required', 'in:東京都,大阪府,福岡県'],
+            'shop_data.*.genre' => ['required', 'in:寿司,焼肉,イタリアン,居酒屋,ラーメン'],
+            'shop_data.*.detail' => ['required', 'max:400'],
+            'shop_data.*.image' => ['required'],
+            'images' => 'required',
+            'images.*' => [
+                'extensions:jpeg,jpg,png',
+                'mimes:jpeg,jpg,png',
+                'max:10240'
+            ],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'images.*.mimes' => '画像にはjpeg, jpg, png形式のファイルを指定してください。',
+            'images.*.extensions' => '画像には拡張子が「.jpeg」「.jpg」「.png」何れかのファイルを指定して下さい。',
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        // csvから「店舗情報配列」と「必要な画像ファイル名の配列」を作成しrequestへ追加
+        if ($this->file('csv')) {
+            $csvData = File::get($this->file('csv'));
+            $rows = explode("\n", trim($csvData));
+
+            for ($i = 1; $i < count($rows); $i++) {
+                $data = str_getcsv($rows[$i]);
+
+                // 店舗情報配列
+                $shop_data[$i] = [
+                    'owner_id' => empty($data[0]) ? null : $data[0],
+                    'name' => empty($data[1]) ? null : $data[1],
+                    'area' => empty($data[2]) ? null : $data[2],
+                    'genre' => empty($data[3]) ? null : $data[3],
+                    'detail' => empty($data[4]) ? null : $data[4],
+                    'image' => empty($data[5]) ? null : "img/".$data[5],
+                    'prepayment_enabled' => false,
+                ];
+
+                // 必要な画像ファイル名の配列
+                if (!empty($data[5])) {
+                    $need_image_names[] = $data[5];
+                }
+            }
+
+            // requestに項目追加
+            if (isset($shop_data)) {
+                $this->merge(compact('shop_data'));
+            }
+            if (isset($need_image_names)) {
+                $need_image_names = array_unique($need_image_names);
+                $this->merge(compact('need_image_names'));
+            }
+        }
+
+        // 「受け取った画像ファイル名の配列」を作成しrequestに追加
+        if ($this->images) {
+            foreach ($this->images as $image) {
+                $input_image_names[] = $image->getClientOriginalName();
+            }
+            $this->merge(compact('input_image_names'));
+        }
+    }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator) {
+                // csv内に一つも店舗情報が無い場合
+                if (!isset($this->shop_data)) {
+                    $validator->errors()->add(
+                        'csv',
+                        'csvに店舗情報が含まれていません'
+                    );
+                }
+
+                // 画像ファイルが不足している場合
+                if (isset($this->need_image_names) && isset($this->input_image_names)) {
+                    $diff_image_names = array_diff($this->need_image_names, $this->input_image_names);
+
+                    if ($diff_image_names) {
+                        $validator->errors()->add(
+                            'images',
+                            '画像ファイルが不足しています'
+                        );
+                    }
+                }
+            }
+        ];
+    }
+}

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -163,6 +163,12 @@ return [
         'courses.*.duration_minutes' => 'コース時間',
         'courses.*.price' => 'コース金額',
         'reserve_prepayment' => 'お支払い方法',
+        'shop_data.*.owner_id' => '店舗のオーナーID',
+        'shop_data.*.name' => '店舗名',
+        'shop_data.*.area' => '店舗の地域',
+        'shop_data.*.genre' => '店舗のジャンル',
+        'shop_data.*.detail' => '店舗の説明文',
+        'shop_data.*.image' => '店舗の画像ファイル名',
 ],
 
     'values' => [

--- a/public/css/admin/register_shop_from_csv.css
+++ b/public/css/admin/register_shop_from_csv.css
@@ -1,0 +1,244 @@
+.register-wrapper {
+    margin: 0 auto;
+    max-width: 1000px;
+}
+
+.message {
+    margin-bottom: 10px;
+    padding: 10px 0;
+    text-align: center;
+    white-space: pre-wrap;
+}
+
+.result--true {
+    color: #9CBAAB;
+    background-color: #BCE1CF;
+    border: solid 1px #9CBAAB;
+    border-radius: 6px;
+}
+
+.result--false {
+    color: #FF475F;
+    background-color: #FEADB8;
+    border: solid 1px #FF475F;
+    border-radius: 6px;
+}
+
+.register-content {
+    width: 100%;
+    border: solid 1px #959997;
+    border-radius: 8px;
+    box-shadow: 2px 2px 3px #aaa;
+}
+
+.register-content__heading {
+    padding: 4px;
+    background-color: #383838;
+    border-bottom: solid 1px #959997;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+}
+
+.register-content__heading h2 {
+    margin: 0;
+    color: white;
+    font-size: 16px;
+    letter-spacing: 0.1em;
+    text-align: center;
+}
+
+.form-table {
+    width: 100%;
+}
+
+.form-table tr {
+    border-bottom: solid 1px #959997;
+}
+
+.form-table th {
+    width: 20%;
+    padding: 10px 20px;
+    border-right: solid 1px #959997;
+    font-weight: normal;
+    text-align: left;
+    background-color: #E0E5E3;
+}
+
+.form-table td {
+    width: 80%;
+    padding: 10px 20px;
+}
+
+.csv-preview__box {
+    margin-top: 10px;
+    width: 100%;
+    font-size: 14px;
+    border: solid 1px #959997;
+}
+
+.csv-preview__head {
+    padding: 0 8px;
+    background-color: #E0E5E3;
+    border-bottom: solid 1px #959997;
+}
+
+.csv-preview__body {
+    min-height: 100px;
+    max-height: 400px;
+    padding: 0 10px;
+    font-size: 14px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+}
+
+.csv-error-message {
+    margin-top: 10px;
+}
+
+.drop-area {
+    margin-bottom: 20px;
+    width: 100%;
+    aspect-ratio: 4/1;
+    background-color: #f4f4f4;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+}
+
+.drop-area__text {
+    margin: 10px 0 0 0;
+    font-size: 16px;
+}
+
+.drop-area__preview {
+    width: 100%;
+}
+
+.form-table__notice {
+    font-size: 14px;
+    color: red;
+}
+
+.input-image-button {
+    padding: 1px 6px;
+    font-size: 14px;
+    border: solid 1px #767676;
+    border-radius: 3px;
+    background-color: #efefef;
+}
+
+.input-image-reset-button {
+    margin-left: 10px;
+    font-size: 14px;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.image-name-preview {
+    margin-top: 10px;
+    display: flex;
+    gap: 10px;
+}
+
+.image-name-preview__box {
+    width: 50%;
+    font-size: 14px;
+    border: solid 1px #959997;
+    display: flex;
+    flex-direction: column;
+}
+
+.image-name-preview__head {
+    padding: 0 8px;
+    background-color: #E0E5E3;
+    border-bottom: solid 1px #959997;
+}
+
+.image-name-preview__body {
+    min-height: 100px;
+    max-height: 400px;
+    overflow: auto;
+    flex-grow: 1;
+}
+
+.input-image-error {
+    color: red;
+}
+
+.hidden {
+    display: none;
+}
+
+.image-name-preview--false {
+    background-color: #FEADB8;
+}
+
+.image-name-preview--true {
+    background-color: #BCE1CF;
+}
+
+.form__button {
+    margin: 20px 0;
+    text-align: center;
+}
+
+.form__button-submit {
+    width: 40%;
+    padding: 8px 0;
+    color: white;
+    background-color: #434343;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.form__button-submit:disabled {
+    background-color: #959997;
+    cursor: default;
+}
+
+.form-table__error {
+    padding: 10px 20px;
+    background-color: #FEADB8;
+    font-size: 14px;
+    font-weight: bold;
+    color: red;
+}
+
+.form-table__error ul {
+    margin: 0;
+}
+
+/* レスポンシブ（タブレット） */
+@media screen and (max-width: 960px) {
+    .form-table th,
+    .form-table td {
+        width: 100%;
+        display: block;
+    }
+
+    .form-table th {
+        padding: 4px 10px;
+        border-bottom: solid 1px #959997;
+        border-right: none;
+    }
+
+    .form-table td {
+        padding: 10px;
+    }
+}
+
+/* レスポンシブ（スマホ） */
+@media screen and (max-width: 480px) {
+    .image-name-preview {
+        display: block;
+    }
+
+    .image-name-preview__box {
+        margin-top: 10px;
+        width: 100%;
+    }
+}

--- a/public/js/register_shop_from_csv.js
+++ b/public/js/register_shop_from_csv.js
@@ -1,0 +1,178 @@
+//********************************************************************
+// CSVファイルインポート
+//********************************************************************
+
+const inputCSV = document.getElementById('input-csv');
+const previewCSV = document.getElementById('csv-preview');
+const previewNeedImageName = document.getElementById('need-image-list');
+var needImageNameList = [];
+
+/**
+ * csvファイル変更時
+ */
+inputCSV.addEventListener('change', function (e) {
+    const reader = new FileReader();
+    const file = e.target.files[0];
+    const message = document.getElementById('csv-error-message');
+
+    // エラーメッセージ初期化
+    while (message.firstChild) {
+        message.removeChild(message.firstChild)
+    }
+    // プレビュー表示の初期化
+    previewCSV.textContent = null;
+    // 必要な画像ファイル名表示の初期化
+    while (previewNeedImageName.firstChild) {
+        previewNeedImageName.removeChild(previewNeedImageName.firstChild)
+    }
+    // 選択済み画像ファイルのリセット
+    resetImageFiles();
+
+    // csv読み込み＆中身のプレビュー
+    if (file.type === 'text/csv') {
+        reader.onload = () => {
+            // csv読み込み
+            const data = reader.result.trim().split('\n').map((row) => row.trim().split(','));
+
+            if (data[0].toString() === "owner_id,name,area,genre,detail,image") {
+                // プレビュー表示
+                previewCSV.textContent = reader.result;
+                // 必要な画像ファイル名をプレビュー表示
+                const FileList = [];
+                for (i = 1; i < data.length; i++) {
+                    if (data[i][5]) {
+                        FileList.push(data[i][5]);
+                    }
+                }
+                needImageNameList = Array.from(new Set(FileList));
+                needImageNameList.sort();
+                needImageNameList.forEach((imageName) => {
+                    const name = document.createElement("li");
+                    name.textContent = imageName;
+                    previewNeedImageName.appendChild(name);
+                });
+            } else {
+                // csvの中身が不正
+                const errorMessage = document.createElement("div");
+                errorMessage.classList.add('form-table__error');
+                errorMessage.textContent = "CSVファイルの記述が不正です。以下カラムが正しく含まれているか確認して下さい。\n" + "owner_id,name,area,genre,detail,image";
+                message.appendChild(errorMessage);
+
+                inputCSV.value = null;
+                needImageNameList = [];
+            }
+        }
+        reader.readAsText(file);
+    } else {
+        // 不正なファイル
+        const errorMessage = document.createElement("div");
+        errorMessage.classList.add('form-table__error');
+        errorMessage.textContent = "CSVファイルを選択して下さい";
+        message.appendChild(errorMessage);
+
+        inputCSV.value = null;
+        needImageNameList = [];
+    }
+});
+
+//********************************************************************
+// 画像追加：画像ファイルを選択、またはドラッグ＆ドロップで追加
+//********************************************************************
+
+const dropTarget = document.getElementById('drop-target');
+const inputImage = document.getElementById("input-image");
+const previewInputImageName = document.getElementById('input-image-list');
+const errorMessageSpan = document.getElementById('input-image-error');
+var imageList = [];
+
+/**
+ * 画像ドラッグ時
+ */
+dropTarget.addEventListener('dragover', function (e) {
+	e.preventDefault();
+	e.stopPropagation();
+	e.dataTransfer.dropEffect = 'copy';
+});
+
+/**
+ * 画像ドロップ時
+ */
+dropTarget.addEventListener('drop', function (e) {
+	e.stopPropagation();
+    e.preventDefault();
+
+    const files = e.dataTransfer.files;
+    addImageFiles(files);
+});
+
+/**
+ * 画像変更時
+ */
+inputImage.addEventListener('change', function (e) {
+    const files = e.target.files;
+    addImageFiles(files);
+});
+
+/**
+ * 画像ファイル追加メソッド
+ * @param {FileList} files 読み込んだ画像ファイル
+ */
+function addImageFiles(files) {
+    const dt = new DataTransfer();
+    const inputImageNameList = [];
+
+    imageList.forEach((image) => {
+        dt.items.add(image);
+    });
+
+    for (i = 0; i < files.length; i++) {
+        if (!imageList.some(image => image.name === files[i].name)) {
+            dt.items.add(files[i]);
+            imageList.push(files[i]);
+        }
+    };
+
+    inputImage.files = dt.files;
+
+    // 画像ファイル名表示
+    while(previewInputImageName.firstChild){
+        previewInputImageName.removeChild(previewInputImageName.firstChild)
+    }
+    imageList.forEach((image) => {
+        // ファイル名のみの配列を作成
+        inputImageNameList.push(image.name);
+    });
+    inputImageNameList.sort();
+    inputImageNameList.forEach((inputImageName) => {
+        const name = document.createElement("li");
+        name.textContent = inputImageName;
+        previewInputImageName.appendChild(name);
+    });
+
+    const diff = needImageNameList.filter(needImage =>
+        inputImageNameList.indexOf(needImage) == -1
+    );
+    if (diff.length === 0) {
+        dropTarget.classList.remove('image-name-preview--false');
+        errorMessageSpan.classList.add('hidden');
+    } else {
+        dropTarget.classList.add('image-name-preview--false');
+        errorMessageSpan.classList.remove('hidden');
+    }
+}
+
+/**
+ * 画像リセットメソッド
+ */
+function resetImageFiles() {
+    // 選択ファイルのリセット
+    inputImage.value = null;
+    imageList = [];
+    // 選択したファイル名の表示をリセット
+    while(previewInputImageName.firstChild){
+        previewInputImageName.removeChild(previewInputImageName.firstChild)
+    }
+    // エラー表示のリセット
+    dropTarget.classList.remove('image-name-preview--false');
+    errorMessageSpan.classList.add('hidden');
+}

--- a/resources/views/admin/app_admin.blade.php
+++ b/resources/views/admin/app_admin.blade.php
@@ -40,29 +40,33 @@
         <div class="side-menu">
             <ul class="side-menu__list">
                 <li class="menu-list-item">
-                    <img class="menu-icon" src="{{ asset('img/home.svg') }}" alt="home">
+                    <img class="menu-icon" src="{{ asset('img/home.svg') }}" alt="">
                     <a href="/">サイトトップへ</a>
                 </li>
                 @if (Auth::user()->role_id == 1)
                 <li class="menu-list-item">
-                    <img class="menu-icon" src="{{ asset('img/register.svg') }}" alt="home">
+                    <img class="menu-icon" src="{{ asset('img/register.svg') }}" alt="">
                     <a href="/admin/register_shop_owner">店舗代表者登録</a>
                 </li>
                 <li class="menu-list-item">
-                    <img class="menu-icon" src="{{ asset('img/mail_white.svg') }}" alt="home">
+                    <img class="menu-icon" src="{{ asset('img/mail_white.svg') }}" alt="">
                     <a href="/admin/admin_mail">お知らせメール</a>
+                </li>
+                <li class="menu-list-item">
+                    <img class="menu-icon" src="{{ asset('img/shop.svg') }}" alt="">
+                    <a href="/admin/register_shop_from_csv">店舗一括登録</a>
                 </li>
                 @endif
                 @if (Auth::user()->role_id == 2)
                 <li class="menu-list-item">
-                    <img class="menu-icon"  src="{{ asset('img/register.svg') }}" alt="home">
+                    <img class="menu-icon"  src="{{ asset('img/register.svg') }}" alt="">
                     <a href="/admin/register_shop_data">新規登録</a>
                 </li>
                 <li class="menu-list-item">
                     <details>
                         <summary>
                             <span class="summary__inner">
-                                <img class="menu-icon"  src="{{ asset('img/shop.svg') }}" alt="home">
+                                <img class="menu-icon"  src="{{ asset('img/shop.svg') }}" alt="">
                                 店舗情報の編集
                                 <img class="open-close-icon" src="{{ asset('img/arrow.svg') }}">
                             </span>
@@ -82,7 +86,7 @@
                     <details>
                         <summary>
                             <span class="summary__inner">
-                                <img class="menu-icon"  src="{{ asset('img/reservation.svg') }}" alt="home">
+                                <img class="menu-icon"  src="{{ asset('img/reservation.svg') }}" alt="">
                                 予約一覧
                                 <img class="open-close-icon" src="{{ asset('img/arrow.svg') }}">
                             </span>

--- a/resources/views/admin/register_shop_from_csv.blade.php
+++ b/resources/views/admin/register_shop_from_csv.blade.php
@@ -1,0 +1,81 @@
+@extends('admin.app_admin')
+
+@section('css')
+<link rel="stylesheet" href="{{ asset('css/admin/register_shop_from_csv.css') }}">
+@endsection
+
+@section('content')
+<div class="register-wrapper">
+    @if(session('result') === true)
+    <div class="message result--true">{{ session('message') }}</div>
+    @elseif(session('result') === false)
+    <div class="message result--false">{{ session('message') }}</div>
+    @endif
+    <div class="register-content">
+        <div class="register-content__heading">
+            <h2>CSVインポート</h2>
+        </div>
+        <form action="/admin/register_shop_from_csv" class="register-content__form" method="post" enctype="multipart/form-data">
+            @csrf
+            <table class="form-table">
+                @if (count($errors) > 0)
+                <tr>
+                    <div class="form-table__error">
+                        <span>【入力エラー】</span>
+                        <ul id="error-message-list">
+                            @foreach ($errors->all() as $error)
+                            <li>{{$error}}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </tr>
+                @endif
+                <tr>
+                    <th>CSVファイル</th>
+                    <td>
+                        <input class="form-table__input--file" id="input-csv" type="file" accept="text/csv" name="csv">
+                        <div class="csv-error-message" id="csv-error-message"></div>
+                        <div class="csv-preview__box">
+                            <div class="csv-preview__head">プレビュー表示</div>
+                            <div class="csv-preview__body" id="csv-preview"></div>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <th>画像ファイル</th>
+                    <td>
+                        <label class="input-image-button" for="input-image">+ファイル追加</label>
+                        <input class="form-table__input--file" id="input-image" type="file" accept="image/png, image/jpeg" name="images[]" multiple hidden>
+                        <span onclick="resetImageFiles()" class="input-image-reset-button">リセット</span>
+                        <div class="image-name-preview">
+                            <div class="image-name-preview__box">
+                                <div class="image-name-preview__head">
+                                    <span>選択したファイル</span>
+                                    <span class="input-image-error hidden" id="input-image-error">※ファイル不足</span>
+                                </div>
+                                <div class="image-name-preview__body" id="drop-target">
+                                    <ul id="input-image-list"></ul>
+                                </div>
+                            </div>
+                            <div class="image-name-preview__box">
+                                <div class="image-name-preview__head">
+                                    <span>必要なファイル</span>
+                                </div>
+                                <div class="image-name-preview__body">
+                                    <ul id="need-image-list"></ul>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+
+            <div class="form__button">
+                <button class="form__button-submit" id="js-submit-button">一括登録</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script src="{{ asset('js/register_shop_from_csv.js') }}"></script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,8 @@ Route::group(['prefix' => 'admin'], function () {
         Route::post('/register_shop_owner', [AdminController::class, 'storeShopOwner']);
         Route::get('/admin_mail', [AdminController::class, 'createAdminMail']);
         Route::post('/admin_mail', [AdminController::class, 'sendAdminMail']);
+        Route::get('/register_shop_from_csv', [AdminController::class, 'createShopDataCSV']);
+        Route::post('/register_shop_from_csv', [AdminController::class, 'storeShopDataCSV']);
     });
 
     Route::group(['middleware' => ['verified', 'auth', 'shop_owner']], function () {


### PR DESCRIPTION
## 【概要】
管理ページにcsvインポートによる店舗一括登録機能を実装

## 【実装内容詳細】
- 管理ページ用レイアウトのサイドメニュー項目に「店舗一括登録」を追加
- 店舗一括登録ページのblade, css, jsファイル作成
	- register_shop_from_csv.blade.php
	- register_shop_from_csv.css
	- register_shop_from_csv.js
- 以下ルーティングとそれに対応するコントローラーメソッドの追加
	- 店舗一括登録ページ表示（AdminController::class, 'createShopDataCSV'）
	- 店舗一括登録処理（AdminController::class, 'storeShopDataCSV'）
- 店舗一括登録用フォームリクエスト作成
	- ShopDataFromCSVRequest.php
- バリデーションメッセージの調整
	- validation.php